### PR TITLE
Fix TypeError on Python 3.9: Path.parents does not support slices

### DIFF
--- a/multiboard/compat.py
+++ b/multiboard/compat.py
@@ -136,7 +136,9 @@ def inproc_hint():
         seeds.append(Path(sys.executable).parent)
     module = getattr(pcbnew(), "__file__", "") or ""
     if module:
-        seeds.extend(Path(module).parents[:6])
+        # list() first: Path.parents accepts slices only on Python 3.10+,
+        # and KiCad's bundled interpreter is 3.9
+        seeds.extend(list(Path(module).parents)[:6])
 
     candidates = []
     for seed in seeds:


### PR DESCRIPTION
## Problem

Launching the action plugin on KiCad builds that bundle Python 3.9 (e.g. KiCad 10 on macOS ships 3.9.13) fails immediately:

```
File ".../multiboard/compat.py", line 139, in inproc_hint
    seeds.extend(Path(module).parents[:6])
File ".../python3.9/pathlib.py", line 644, in __getitem__
    if idx < 0 or idx >= len(self):
TypeError: '<' not supported between instances of 'slice' and 'int'
```

`Path.parents` only accepts slice indices from Python 3.10 onward ([bpo-35498](https://bugs.python.org/issue35498)); on 3.9 the slice object reaches the integer comparison in `__getitem__` and raises. Since `install_hint()` runs during plugin startup, this makes the plugin unusable on 3.9-based KiCad installs.

## Fix

Materialize the parents into a list before slicing — behavior is identical on every Python version:

```python
seeds.extend(list(Path(module).parents)[:6])
```

Verified against KiCad's bundled Python 3.9.13 on macOS (KiCad 10.0): the module compiles and the plugin launches. This was the only slice of `parents` in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)